### PR TITLE
PDF metadata is set according to scraped paper data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
 colorlog
 pydantic
+pypdf
 requests

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "colorlog>=4.1.0",
         "requests",
         "pydantic",
+        "pypdf>=3.10.0",
         "beautifulsoup4",
     ],
     extras_require={


### PR DESCRIPTION
Set the following fields in the PDF metadata (preserve all other set fields):
* Author: authors from paper data, joined by commas
* Title: title from paper data
* Subject: abstract from paper data

Makes PDFs show up nicely on e-readers 😃

Example:
![image](https://github.com/MarkHershey/arxiv-dl/assets/7964300/52886223-2018-48fc-9978-9ba1e154771f)
