### PR TITLE
Handle long author lists

### DIFF
--- a/src/arxiv_dl/scrapers.py
+++ b/src/arxiv_dl/scrapers.py
@@ -55,11 +55,15 @@ def scrape_metadata_arxiv(paper_data: PaperData) -> None:
 
     # get AUTHORS
     result = soup.find("div", class_="authors")
-    author_list = [i.string.strip() for i in result]
-    author_list.pop(0)
-    while "," in author_list:
-        author_list.remove(",")
-    paper_data.authors = author_list
+    try:
+        author_list = [i.string.strip() for i in result]
+        author_list.pop(0)
+        while "," in author_list:
+            author_list.remove(",")
+        paper_data.authors = author_list
+    except AttributeError:
+        paper_data.authors = []
+        logger.warning("[Warn] Unable to retrieve long author list")
 
     # get ABSTRACT
     result = soup.find("blockquote", class_="abstract mathjax")


### PR DESCRIPTION
Hi,
I recently found that running
```
$ paper 2408.13687
```
caused an AttributeError.  This doesn't seem to happen with other papers, but this paper has hundreds of authors...

This error was thrown in src/arxiv_dl/scrapers.py:
```
    author_list = [i.string.strip() for i in result]
                   ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```
the variable `result` was a beautifulsoup query result that ended in

```
...
<a href="javascript:toggleAuthorList('long-author-list','et al. (149 additional authors not shown)');" id="toggle" title="Show Entire Author List">
    et al. (149 additional authors not shown)</a>
<noscript> You must enable JavaScript to view entire author list.</noscript></div>.
```
As such I'm submitting a pull request for your consideration that modifies the program's behaviour to emit a warning if authors are unavailable, rather than an AttributeError.  There may be much better solutions.